### PR TITLE
Add minimal Dockerfile for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:xenial
+
+RUN apt-get update --fix-missing && apt-get install --no-install-recommends -y \
+    vim nano \
+    build-essential cmake g++ libboost-all-dev libxerces-c-dev xsdcxx \
+    ansible python-django python-pip python-setuptools
+
+ENV HOME /root
+USER root
+WORKDIR /root


### PR DESCRIPTION
This is a minimal Docker image configuration
just enough to replace Vagrant (#107) for developer machines.

This may require updating the documentation & wiki
with, for example, instructions to launch the docker container by mounting the git repo for development:

```bash
docker build -t fuzzed_image .
docker run -it -v /path/to/fuzzed/repo:/root/fuzzed fuzzed_image
```

All the backend & frontend builds work just as is described in the README.
However, I don't know how this is going to work with the existing tests.
Is there documentation how to run tests?